### PR TITLE
Add basic Flask app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Virtual environment
+venv/
+.venv/
+
+# Python
+__pycache__/
+*.py[cod]
+
+# Env files
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Hedgehog-Data-Conversion
+# Hedgehog Data Conversion
+
+This project contains a simple Flask application configured to use HTMX, Pandas, and Flask Sessions. Credentials such as `SECRET_KEY` should be provided via environment variables or a `.env` file (excluded from version control).
+
+## Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run the development server with:
+
+```bash
+python run.py
+```
+
+Run the tests with:
+
+```bash
+pytest
+```
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+from flask_session import Session
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev')
+app.config['SESSION_TYPE'] = 'filesystem'
+Session(app)
+
+from . import routes

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,6 @@
+from . import app
+from flask import render_template
+
+@app.route('/')
+def index():
+    return render_template('index.html')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Hello</title>
+    <script src="https://unpkg.com/htmx.org@1.9.9"></script>
+</head>
+<body>
+    <h1>Hello World</h1>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-Session
+pandas

--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,17 @@
+import os, sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_index(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b"Hello World" in response.data


### PR DESCRIPTION
## Summary
- add a Flask application skeleton with HTMX
- include pandas and flask-session in requirements
- setup environment variables for secret credentials
- add simple unit test for the index route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6861656d0d10832196375d0aa27e2393