### PR TITLE
Add Bootstrap layout with sidebar navigation

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,10 +2,40 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Hello</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Hedgehog Data Conversion Utility</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@1.9.9"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 <body>
-    <h1>Hello World</h1>
+<div class="container-fluid">
+    <div class="row">
+        <button class="btn btn-primary d-md-none my-2" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation">
+            &#9776;
+        </button>
+        <nav id="sidebar" class="col-md-3 col-lg-2 d-md-block bg-light collapse show">
+            <div class="position-sticky pt-3">
+                <h5 class="ps-3">Configuration</h5>
+                <ul class="nav flex-column mb-4">
+                    <li class="nav-item"><a class="nav-link" href="#">Service Providers</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#">Fee Model</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#">Inspection Model</a></li>
+                </ul>
+                <h5 class="ps-3">Core</h5>
+                <ul class="nav flex-column">
+                    <li class="nav-item"><a class="nav-link" href="#">Site</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#">Facility</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#">Permit</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#">Account</a></li>
+                </ul>
+            </div>
+        </nav>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <h1 class="mt-4">Hedgehog Data Conversion Utility</h1>
+            <!-- Future features will appear here -->
+        </main>
+    </div>
+</div>
 </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -14,4 +14,4 @@ def client():
 def test_index(client):
     response = client.get('/')
     assert response.status_code == 200
-    assert b"Hello World" in response.data
+    assert b"Hedgehog Data Conversion Utility" in response.data


### PR DESCRIPTION
## Summary
- restyle the hello page with Bootstrap
- add collapsible sidebar navigation
- update tests for the new title

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686168470b488321b01b22388693d954