### PR TITLE
Implement SQL schema grid

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -4,3 +4,15 @@ from flask import render_template
 @app.route('/')
 def index():
     return render_template('index.html')
+from flask import jsonify
+from .sql_utils import get_table_columns, SchemaError
+
+
+@app.route('/schema/<table_name>')
+def schema(table_name):
+    try:
+        columns = get_table_columns(table_name)
+        return jsonify(columns)
+    except SchemaError as e:
+        return jsonify({'error': str(e)}), 400
+

--- a/app/sql_utils.py
+++ b/app/sql_utils.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import re
+
+SCHEMA_DIR = Path(__file__).resolve().parent.parent / 'schema'
+
+class SchemaError(Exception):
+    pass
+
+
+def _read_latest_sql_file():
+    sql_files = list(SCHEMA_DIR.glob('*.sql'))
+    if not sql_files:
+        raise SchemaError('No SQL files found in schema directory')
+    latest = max(sql_files, key=lambda p: p.stat().st_mtime)
+    with latest.open('rb') as f:
+        data = f.read()
+    # detect UTF-16 LE/BE BOM
+    if data.startswith(b'\xff\xfe'):
+        text = data.decode('utf-16le')
+    elif data.startswith(b'\xfe\xff'):
+        text = data.decode('utf-16be')
+    else:
+        text = data.decode('utf-8')
+    return text
+
+
+def get_table_columns(table_name: str):
+    text = _read_latest_sql_file()
+    # regex to capture CREATE TABLE statement
+    pattern = rf"CREATE TABLE \[dbo\]\.\[{re.escape(table_name)}\]\((.*?)\)\s*CONSTRAINT"
+    match = re.search(pattern, text, re.S | re.IGNORECASE)
+    if not match:
+        raise SchemaError(f'Table {table_name} not found in schema')
+    body = match.group(1)
+    columns = []
+    for line in body.splitlines():
+        line = line.strip().rstrip(',')
+        if not line or line.upper().startswith('CONSTRAINT'):
+            continue
+        m = re.match(r"\[(?P<name>[^\]]+)\]\s+(?P<type>\w+(?:\([^\)]*\))?)", line)
+        if m:
+            columns.append({'field': m.group('name'), 'type': m.group('type')})
+    return columns

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,8 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hedgehog Data Conversion Utility</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://unpkg.com/htmx.org@1.9.9"></script>
+    <link href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.9"></script>
 </head>
 <body>
 <div class="container-fluid">
@@ -24,18 +27,50 @@
                 </ul>
                 <h5 class="ps-3">Core</h5>
                 <ul class="nav flex-column">
-                    <li class="nav-item"><a class="nav-link" href="#">Site</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#">Facility</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#">Permit</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#">Account</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" onclick="loadSchema('Site')">Site</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" onclick="loadSchema('Facility')">Facility</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" onclick="loadSchema('Permit')">Permit</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" onclick="loadSchema('Account')">Account</a></li>
                 </ul>
             </div>
         </nav>
         <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
             <h1 class="mt-4">Hedgehog Data Conversion Utility</h1>
-            <!-- Future features will appear here -->
+            <table id="schemaTable" class="display w-100">
+                <thead>
+                    <tr>
+                        <th>Fieldname</th>
+                        <th>Data Type</th>
+                        <th>Source</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+</table>
         </main>
     </div>
 </div>
+<script>
+function loadSchema(name) {
+    fetch('/schema/' + name)
+        .then(r => r.json())
+        .then(data => {
+            if (data.error) {
+                alert(data.error);
+                return;
+            }
+            var table = $('#schemaTable');
+            if ($.fn.dataTable.isDataTable(table)) {
+                table.DataTable().clear().destroy();
+            }
+            table.find('tbody').empty();
+            data.forEach(function(row){
+                table.find('tbody').append('<tr><td>'+row.field+'</td><td>'+row.type+'</td><td></td></tr>');
+            });
+            table.DataTable({
+                autoWidth: true
+            });
+        });
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- parse latest SQL schema file to extract table columns
- expose `/schema/<table>` route for fetching column metadata
- add DataTables grid to UI and load selected schema via AJAX

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68617454b2bc832186ab0f4ca5d89268