### PR TITLE
Refactor schema loading to use sqlite

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,10 +1,13 @@
 from flask import Flask
 from flask_session import Session
 import os
+from .sql_utils import initialize_schema_cache
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev')
 app.config['SESSION_TYPE'] = 'filesystem'
 Session(app)
+
+initialize_schema_cache()
 
 from . import routes

--- a/app/sql_utils.py
+++ b/app/sql_utils.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 import re
+import sqlite3
 
 SCHEMA_DIR = Path(__file__).resolve().parent.parent / 'schema'
+DB_PATH = Path(__file__).resolve().parent / 'schema_cache.sqlite'
 
 class SchemaError(Exception):
     pass
@@ -21,30 +23,75 @@ def _read_latest_sql_file():
         text = data.decode('utf-16be')
     else:
         text = data.decode('utf-8')
-    return text
+    return text, latest.stat().st_mtime
+
+
+def _parse_schema(text: str):
+    """Parse the SQL text and yield (table, field, type) tuples."""
+    lines = text.splitlines()
+    results = []
+    i = 0
+    table_re = re.compile(r"^CREATE TABLE \[dbo\]\.\[(?P<table>[^\]]+)\]\s*\(", re.IGNORECASE)
+    while i < len(lines):
+        m = table_re.search(lines[i])
+        if m:
+            table = m.group('table')
+            i += 1
+            while i < len(lines):
+                stripped = lines[i].strip().rstrip(',')
+                if not stripped or stripped.upper().startswith('CONSTRAINT'):
+                    break
+                cm = re.match(r"\[(?P<name>[^\]]+)\]\s+(?P<type>\w+(?:\([^\)]*\))?)", stripped)
+                if cm:
+                    results.append((table, cm.group('name'), cm.group('type')))
+                i += 1
+        else:
+            i += 1
+    return results
+
+
+def _ensure_db(text: str, mtime: float):
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    with conn:
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT)'
+        )
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS columns (table_name TEXT, field_name TEXT, data_type TEXT)'
+        )
+        cur = conn.execute(
+            "SELECT value FROM metadata WHERE key='schema_mtime'"
+        )
+        row = cur.fetchone()
+        if row and float(row[0]) == mtime:
+            return
+        conn.execute('DELETE FROM columns')
+        for table, field, dtype in _parse_schema(text):
+            conn.execute(
+                'INSERT INTO columns(table_name, field_name, data_type) VALUES(?,?,?)',
+                (table, field, dtype),
+            )
+        conn.execute(
+            'REPLACE INTO metadata(key, value) VALUES(?, ?)',
+            ('schema_mtime', str(mtime)),
+        )
+    conn.close()
+
+
+def initialize_schema_cache():
+    text, mtime = _read_latest_sql_file()
+    _ensure_db(text, mtime)
 
 
 def get_table_columns(table_name: str):
-    text = _read_latest_sql_file()
-    lines = text.splitlines()
-
-    start_re = re.compile(rf"^CREATE TABLE \[dbo\]\.\[{re.escape(table_name)}\]\(", re.IGNORECASE)
-    start_idx = None
-    for i, line in enumerate(lines):
-        if start_re.search(line):
-            start_idx = i + 1
-            break
-
-    if start_idx is None:
+    conn = sqlite3.connect(DB_PATH)
+    with conn:
+        rows = conn.execute(
+            'SELECT field_name, data_type FROM columns WHERE table_name=?',
+            (table_name,),
+        ).fetchall()
+    conn.close()
+    if not rows:
         raise SchemaError(f'Table {table_name} not found in schema')
-
-    columns = []
-    for line in lines[start_idx:]:
-        stripped = line.strip().rstrip(',')
-        if not stripped or stripped.upper().startswith('CONSTRAINT'):
-            break
-        m = re.match(r"\[(?P<name>[^\]]+)\]\s+(?P<type>\w+(?:\([^\)]*\))?)", stripped)
-        if m:
-            columns.append({'field': m.group('name'), 'type': m.group('type')})
-
-    return columns
+    return [{'field': r[0], 'type': r[1]} for r in rows]


### PR DESCRIPTION
## Summary
- cache parsed SQL schema into a SQLite database
- only refresh if schema file changed
- initialize cache on app startup
- read schema information from SQLite instead of parsing SQL file for each request

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686182d5c7c883218dd0368d0d1a2493